### PR TITLE
feat: allow zero offer collateral for single-funded DLCs

### DIFF
--- a/ddk-manager/src/contract/contract_input.rs
+++ b/ddk-manager/src/contract/contract_input.rs
@@ -89,9 +89,10 @@ pub struct ContractInput {
 impl ContractInput {
     /// Validate the contract input parameters
     pub fn validate(&self) -> Result<(), Error> {
-        if self.offer_collateral < DUST_LIMIT {
+        // Allow 0 collateral for single-funded DLCs, but non-zero must exceed dust limit
+        if self.offer_collateral > Amount::ZERO && self.offer_collateral < DUST_LIMIT {
             return Err(Error::InvalidParameters(
-                "Offer collateral must be greater than dust limit.".to_string(),
+                "Non-zero offer collateral must be greater than dust limit.".to_string(),
             ));
         }
 


### PR DESCRIPTION
## Summary

Updates contract input validation to allow zero offer collateral, enabling single-funded DLC use cases where one party provides all the collateral.

## Changes

- Modified `offer_collateral` validation to only check dust limit when collateral is non-zero
- Updated error message to clarify "non-zero offer collateral" must exceed dust limit
- Added explanatory comment for the single-funded DLC use case